### PR TITLE
Good shit

### DIFF
--- a/app/Http/Controllers/BookController.php
+++ b/app/Http/Controllers/BookController.php
@@ -62,6 +62,7 @@ class BookController extends Controller
             'filter'               => $filters,
             'currentSortField'     => $sortField,
             'currentSortDirection' => $sortDirection,
+            'newBookData'          => session()->get('new_book_data'), // Pass flash data explicitly
         ]);
     }
 
@@ -199,7 +200,11 @@ class BookController extends Controller
             DB::commit();
 
             return to_route('books.index')
-                ->with('success', 'Book record created successfully.');
+                ->with('success', 'Book record created successfully.')
+                ->with('new_book_data', [
+                    'title' => $request->title,
+                    'accession_number' => $request->accession_number
+                ]);
         } catch (\Illuminate\Database\QueryException $e) {
             DB::rollBack();
             Log::error('Database error creating Book: ' . $e->getMessage(), [

--- a/resources/js/components/QRCodeModal.vue
+++ b/resources/js/components/QRCodeModal.vue
@@ -71,7 +71,7 @@ const emit = defineEmits<{
 const qrCodeRef = ref()
 
 const qrValue = computed(() => {
-  return `Title: ${props.data.title}, Accession: ${props.data.accession_number}`
+  return props.data.accession_number
 })
 
 const downloadQRCode = () => {

--- a/resources/js/components/QRCodeModal.vue
+++ b/resources/js/components/QRCodeModal.vue
@@ -13,12 +13,14 @@
           <QRCodeVue3
             ref="qrCodeRef"
             :value="qrValue"
-            :width="200"
-            :height="200"
+            :width="1000"
+            :height="1000"
             :corners-square-color="'#000000'"
             :corners-dot-color="'#000000'"
             :color="'#000000'"
             :bg-color="'#ffffff'"
+            :margin="1"
+            :quality-level="'H'"
           />
         </div>
 

--- a/resources/js/components/QRCodeModal.vue
+++ b/resources/js/components/QRCodeModal.vue
@@ -1,0 +1,50 @@
+<template>
+  <Dialog :open="open" @update:open="$emit('update:open', $event)">
+    <DialogContent class="sm:max-w-md">
+      <DialogHeader>
+        <DialogTitle>Book Created Successfully!</DialogTitle>
+        <DialogDescription>
+          Your book record has been created successfully.
+        </DialogDescription>
+      </DialogHeader>
+
+      <div class="flex flex-col items-center space-y-4 py-4">
+        <div class="text-center space-y-2">
+          <h3 class="font-semibold text-lg">{{ data.title }}</h3>
+          <p class="text-sm text-gray-600">Accession Number: {{ data.accession_number }}</p>
+          <div class="bg-gray-100 p-4 rounded-lg">
+            <p class="text-xs text-gray-500 mb-2">QR Code Data:</p>
+            <p class="text-sm font-mono">Title: {{ data.title }}, Accession: {{ data.accession_number }}</p>
+          </div>
+        </div>
+      </div>
+
+      <DialogFooter>
+        <Button @click="$emit('update:open', false)">
+          Close
+        </Button>
+      </DialogFooter>
+    </DialogContent>
+  </Dialog>
+</template>
+
+<script setup lang="ts">
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+
+interface BookData {
+  title: string
+  accession_number: string
+}
+
+interface Props {
+  open: boolean
+  data: BookData
+}
+
+defineProps<Props>()
+
+defineEmits<{
+  'update:open': [value: boolean]
+}>()
+</script>

--- a/resources/js/pages/books/Index.vue
+++ b/resources/js/pages/books/Index.vue
@@ -74,28 +74,11 @@ const newBookData = ref({
 
 // Check for new book data from props (passed from controller)
 onMounted(() => {
-    console.log('Index.vue onMounted - checking for book data')
-    console.log('props.newBookData:', props.newBookData)
-    console.log('page.props.flash:', page.props.flash)
-
     if (props.newBookData) {
-        console.log('Setting newBookData from props and showing modal')
         newBookData.value = props.newBookData
         showQRModal.value = true
-    } else {
-        console.log('No new book data found in props')
     }
 })
-
-// Test function to manually trigger modal
-const testModal = () => {
-    console.log('Test modal triggered')
-    newBookData.value = {
-        title: 'Test Book Title',
-        accession_number: 'TEST123'
-    }
-    showQRModal.value = true
-}
 
 import type { Row, Column, SortingState, ColumnFiltersState, ColumnDef } from '@tanstack/vue-table'
 type RowData = any
@@ -374,9 +357,6 @@ const handleDelete = (id: any) => {
                         <Button variant="outline" @click="createNewBook">
                             <Plus class="h-4"></Plus>
                             Create New
-                        </Button>
-                        <Button variant="outline" @click="testModal">
-                            Test Modal
                         </Button>
                         <DropdownMenu>
                             <DropdownMenuTrigger as-child>

--- a/resources/js/pages/books/Index.vue
+++ b/resources/js/pages/books/Index.vue
@@ -11,7 +11,7 @@ import {
     getSortedRowModel,
     useVueTable, VisibilityState
 } from '@tanstack/vue-table';
-import { ArrowUpDown, ChevronDown, X } from 'lucide-vue-next'
+import { ArrowUpDown, ChevronDown, X, QrCode } from 'lucide-vue-next'
 
 import { h, ref, onMounted } from 'vue'
 import {
@@ -145,6 +145,23 @@ const columns: ColumnDef<RowData>[] = [
             const date = row.getValue('date_received') as string;
             return h('div', date ? new Date(date).toLocaleDateString() : '');
         },
+    },
+    {
+        id: 'actions',
+        header: () => h('div', 'Actions'),
+        cell: ({ row }: { row: Row<RowData> }) => {
+            return h('div', { class: 'flex items-center gap-2' }, [
+                h(Button, {
+                    variant: 'outline',
+                    size: 'sm',
+                    onClick: () => showQRForBook(row.original),
+                    class: 'h-8 w-8 p-0',
+                    title: 'Show QR Code'
+                }, () => h(QrCode, { class: 'h-4 w-4' }))
+            ])
+        },
+        enableSorting: false,
+        enableHiding: false,
     },
 ];
 
@@ -300,6 +317,15 @@ const breadcrumbs: BreadcrumbItem[] = [
 
 const createNewBook = () => {
     router.get(route('books.create'));
+}
+
+// Function to show QR modal for any book
+const showQRForBook = (book: any) => {
+    newBookData.value = {
+        title: book.title,
+        accession_number: book.accession_number
+    }
+    showQRModal.value = true
 }
 
 const showDeleteAlert = ref(false);


### PR DESCRIPTION
This pull request adds a feature to display and download a QR code for newly created book records. The QR code modal appears automatically after a book is created, and users can also manually open the QR code modal for any book from the index page. The implementation includes backend changes to pass new book data via flash session and frontend changes to render the QR code modal and enable downloading the QR code as a PNG image.

**Backend integration for QR modal:**
* The `BookController` now stores newly created book data (`title` and `accession_number`) in the session flash and passes it to the index view, allowing the frontend to display the QR modal after creation.

**Frontend QR code modal and logic:**
* Added a new `QRCodeModal.vue` component that displays the QR code for a book, shows its details, and provides a button to download the QR code as a PNG image.
* Updated `Index.vue` to automatically show the QR modal if `newBookData` is present (after a book is created), and to allow opening the QR modal for any book via an "Actions" column with a QR code button.

**UI/UX improvements:**
* Added an "Actions" column to the books table with a button to show the QR code for any book record.
* Ensured that the QR code modal is integrated into the page layout and works with the existing flash message and modal systems.

**Code organization and imports:**
* Updated imports in `Index.vue` to include new components and icons needed for the QR code modal and actions.

**Type safety and minor refactoring:**
* Improved type safety for book data and cleaned up some method signatures in the frontend.